### PR TITLE
feat: add new field to vulnerability alert

### DIFF
--- a/src/github/service.ts
+++ b/src/github/service.ts
@@ -650,6 +650,7 @@ export class GitHubService {
       }
       edges {
         node {
+          state
           dismissReason
           vulnerableManifestFilename
           vulnerableManifestPath

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -51,6 +51,7 @@ export interface Repo {
 // See https://developer.github.com/v4/object/repositoryvulnerabilityalert/
 export interface VulnerabilityAlert {
   dismissReason: string | null
+  state: "DISMISSED" | "FIXED" | "OPEN"
   vulnerableManifestFilename: string
   vulnerableManifestPath: string
   vulnerableRequirements: string | null


### PR DESCRIPTION
Include the new, non-nullable field `state` to the GraphQL query for GitHub vulnerability alerts.

See GitHub API changelog for more details on the recent API changes: https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2022-02-16