### PR TITLE
fix: add SonarCloudCliProvider that retrieves environmental variable …

### DIFF
--- a/src/sonarcloud/index.ts
+++ b/src/sonarcloud/index.ts
@@ -1,2 +1,2 @@
 export { createSonarCloudService, SonarCloudService } from "./service"
-export { SonarCloudTokenProvider } from "./token"
+export { SonarCloudTokenProvider, SonarCloudTokenCliProvider } from "./token"

--- a/src/sonarcloud/service.ts
+++ b/src/sonarcloud/service.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch"
 import { Config } from "../config"
-import { SonarCloudTokenProvider } from "./token"
+import { SonarCloudTokenCliProvider, SonarCloudTokenProvider } from "./token"
 
 interface SonarCloudServiceProps {
   config: Config
@@ -75,7 +75,7 @@ export class SonarCloudService {
 
 interface CreateSonarCloudServiceProps {
   config: Config
-  tokenProvider: SonarCloudTokenProvider
+  tokenProvider?: SonarCloudTokenProvider
 }
 
 export function createSonarCloudService(
@@ -83,6 +83,6 @@ export function createSonarCloudService(
 ): SonarCloudService {
   return new SonarCloudService({
     config: props.config,
-    tokenProvider: props.tokenProvider,
+    tokenProvider: props.tokenProvider ?? new SonarCloudTokenCliProvider(),
   })
 }

--- a/src/sonarcloud/token.ts
+++ b/src/sonarcloud/token.ts
@@ -2,3 +2,18 @@ export interface SonarCloudTokenProvider {
   getToken(): Promise<string | undefined>
   markInvalid(): Promise<void>
 }
+export class SonarCloudTokenCliProvider implements SonarCloudTokenProvider {
+  async getToken(): Promise<string | undefined> {
+    if (process.env.CALS_SONARCLOUD_TOKEN) {
+      return Promise.resolve(process.env.CALS_SONARCLOUD_TOKEN)
+    }
+
+    process.stderr.write(
+      "No environmental variable found. Set variable `CALS_SONARCLOUD_TOKEN` to token value\n",
+    )
+    return undefined
+  }
+  async markInvalid(): Promise<void> {
+    await Promise.resolve()
+  }
+}


### PR DESCRIPTION
…for local testing

It is necessary to add an implementation of the interface that retrieves the environmental variable. Otherwise we cannot test the integration locally without specifying an implementation of the interface when we need to test.