### PR TITLE
fix(deps): update to node v18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ buildConfig([
   dockerNode {
     checkout scm
 
-    insideToolImage('node:14') {
+    insideToolImage('node:18') {
       stage('Install dependencies') {
         sh 'npm ci'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/jest": "27.5.2",
         "@types/js-yaml": "4.0.5",
         "@types/lodash": "4.14.191",
-        "@types/node": "14.18.38",
+        "@types/node": "18.16.3",
         "@types/node-fetch": "2.6.2",
         "@types/read": "0.0.29",
         "@types/rimraf": "3.0.2",
@@ -2941,9 +2941,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.38.tgz",
-      "integrity": "sha512-zMRIidN2Huikv/+/U7gRPFYsXDR/7IGqFZzTLnCEj5+gkrQjsowfamaxEnyvArct5hxGA3bTxMXlYhH78V6Cew==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -15309,9 +15309,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.38.tgz",
-      "integrity": "sha512-zMRIidN2Huikv/+/U7gRPFYsXDR/7IGqFZzTLnCEj5+gkrQjsowfamaxEnyvArct5hxGA3bTxMXlYhH78V6Cew==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/jest": "27.5.2",
     "@types/js-yaml": "4.0.5",
     "@types/lodash": "4.14.191",
-    "@types/node": "14.18.38",
+    "@types/node": "18.16.3",
     "@types/node-fetch": "2.6.2",
     "@types/read": "0.0.29",
     "@types/rimraf": "3.0.2",
@@ -76,7 +76,6 @@
     "typescript": "4.9.5",
     "typescript-json-schema": "0.54.0"
   },
-  "peerDependencies": {},
   "files": [
     "lib/**/*"
   ],

--- a/src/testing/lib.ts
+++ b/src/testing/lib.ts
@@ -421,6 +421,11 @@ export async function startContainer({
   process.catch(() => {
     failed = true
   })
+  if (!process.pid) {
+    throw new Error(
+      "No process identifier (PID) was returned for the process that was started when running trying to run Docker container",
+    )
+  }
 
   const id = await getContainerId({
     executor,


### PR DESCRIPTION
Semantic release requires node >= v18, so we need to bump this in order for CI to be able to create releases.