### PR TITLE
fix!: require owner for PR for compatibility with fine grained tokens

### DIFF
--- a/src/cli/commands/github/list-pull-requests-stats.ts
+++ b/src/cli/commands/github/list-pull-requests-stats.ts
@@ -14,7 +14,7 @@ async function listPullRequestsStats({
   // This is only an initial attempt to get some insights into
   // open pull requests. Feel free to change.
 
-  const pulls = await github.getSearchedPullRequestList()
+  const pulls = await github.getSearchedPullRequestList("capralifecycle")
 
   interface Category {
     key: string

--- a/src/github/service.ts
+++ b/src/github/service.ts
@@ -525,13 +525,13 @@ export class GitHubService {
     ]
   }
 
-  public async getSearchedPullRequestList(): Promise<
+  public async getSearchedPullRequestList(owner: string): Promise<
     SearchedPullRequestListItem[]
   > {
     // NOTE: Changes to this must by synced with SearchedPullRequestListQueryResult.
     const getQuery = (after: string | null) => `{
   search(
-    query: "is:open is:pr user:capralifecycle user:capraconsulting archived:false",
+    query: "is:open is:pr user:${owner} owner:${owner} archived:false",
     type: ISSUE,
     first: 100${
       after === null

--- a/src/github/service.ts
+++ b/src/github/service.ts
@@ -252,9 +252,9 @@ export class GitHubService {
 
     if (!response.ok) {
       throw new Error(
-        `Response from GitHub not OK (${response.status}): ${JSON.stringify(
-          response,
-        )}`,
+        `Response from GitHub not OK (${
+          response.status
+        }): ${await response.text()}`,
       )
     }
 

--- a/src/github/service.ts
+++ b/src/github/service.ts
@@ -525,9 +525,9 @@ export class GitHubService {
     ]
   }
 
-  public async getSearchedPullRequestList(owner: string): Promise<
-    SearchedPullRequestListItem[]
-  > {
+  public async getSearchedPullRequestList(
+    owner: string,
+  ): Promise<SearchedPullRequestListItem[]> {
     // NOTE: Changes to this must by synced with SearchedPullRequestListQueryResult.
     const getQuery = (after: string | null) => `{
   search(


### PR DESCRIPTION
The Github Fine Grained Personal Access Tokens require owner in graphql. A fine grained PAT can only access one org/user.