### PR TITLE
feat: update snyk API from v1 to new REST API

### DIFF
--- a/src/snyk/types.ts
+++ b/src/snyk/types.ts
@@ -1,4 +1,42 @@
-// See https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects
+// See https://apidocs.snyk.io/?version=2023-08-04#get-/orgs/-org_id-/projects
+export interface ProjectResponse {
+  data: RestAPIProject[]
+  links: {
+    next?: string
+  }
+}
+
+export interface RestAPIProject {
+  id: string
+  attributes: {
+    name: string
+    type: string
+    origin: string
+    created: string
+    status: string
+    settings: {
+      recurring_tests: {
+        frequency: string
+      }
+    }
+  }
+  status: boolean
+  meta: {
+    latest_dependency_total: {
+      updated_at: string
+      total: number
+    }
+    latest_issue_counts: {
+      critical?: number
+      high: number
+      medium: number
+      low: number
+    }
+  }
+}
+
+/** Type represents format of responses from the deprecated List all projects v1 API
+ https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects **/
 export interface SnykProject {
   name: string
   id: string
@@ -19,6 +57,7 @@ export interface SnykProject {
    * E.g. http://github.com/capralifecycle/some-repo.git
    * Set when using the CLI.
    */
+  // Will be null because it is not yet implemented in the new API
   remoteRepoUrl?: string
   // TODO: Check if lastTestedDate is actually always given - just to be safe now.
   lastTestedDate?: string | null


### PR DESCRIPTION
Snyk is deprecating v1 of the API, which we have used previously - https://snyk.docs.apiary.io/#reference/projects/all-projects/list-all-projects.
We update the Snyk service to use the new REST API (https://apidocs.snyk.io/?version=2023-08-04#get-/orgs/-org_id-/projects), and transform the data to the old format so that the consumers will be backover compatible with the data coming from Snyk.