### PR TITLE
feat: support for plaintext secrets in cals-cli

### DIFF
--- a/src/load-secrets/load-secrets.ts
+++ b/src/load-secrets/load-secrets.ts
@@ -71,6 +71,12 @@ class LoadSecrets {
     }
   }
 
+  async handleStringUpdate() {
+    return await this.getInput({
+      prompt: "Enter value (Ctrl+C to abort): ",
+      silent: this.silent,
+    })
+  }
   async handleJsonUpdate(secret: JsonSecret) {
     this.reporter.log("The secret is of type JSON with these expected fields:")
     for (const field of secret.fields) {
@@ -202,6 +208,8 @@ class LoadSecrets {
         }
         throw e
       }
+    } else if (secret.type === "string") {
+      secretValue = await this.handleStringUpdate()
     } else {
       throw new Error(`Unsupported type`)
     }

--- a/src/load-secrets/types.ts
+++ b/src/load-secrets/types.ts
@@ -11,13 +11,20 @@ export interface JsonSecretDescribedField {
   example?: string
 }
 
+/**
+ * Used for secrets that are a single plaintext string,
+ * and do not require JSON formating.
+ */
+export interface StringSecret extends BaseSecret {
+  type: "string"
+}
+
 export interface JsonSecret extends BaseSecret {
   type: "json"
   fields: (JsonSecretSimpleField | JsonSecretDescribedField)[]
 }
 
-// This can become a union type later if needed.
-export type Secret = JsonSecret
+export type Secret = JsonSecret | StringSecret
 
 export interface SecretGroup {
   accountId: string


### PR DESCRIPTION
This PR makes it possible to create a plaintext secret through cals-cli. Instead of defining a JSON format in load-secrets, the consumer defines a secret of type `string`. Example:

```
const testSecret: loadSecrets.Secret = {
  name: "test-value",
  description: "Test secret value",
  type: "string",
}

```