### PR TITLE
Remove RepoDeleteItem

### DIFF
--- a/src/github/changeset/execute.ts
+++ b/src/github/changeset/execute.ts
@@ -5,7 +5,7 @@ import {
   ReposUpdateParams,
   TeamsListResponseItem,
 } from "../types"
-import { ChangeSetItem, RepoCreateItem, RepoDeleteItem } from "./types"
+import { ChangeSetItem, RepoCreateItem } from "./types"
 
 function buildLookup(github: GitHubService) {
   // We operate using the Octokit SDK, so cache the objects to avoid
@@ -45,11 +45,10 @@ function buildLookup(github: GitHubService) {
   }
 }
 
-type NotImplementedChangeSetItem = RepoCreateItem | RepoDeleteItem
+type NotImplementedChangeSetItem = RepoCreateItem
 
 const notImplementedChangeSetItems: NotImplementedChangeSetItem["type"][] = [
   "repo-create",
-  "repo-delete",
 ]
 
 export function isNotImplementedChangeSetItem(

--- a/src/github/changeset/types.ts
+++ b/src/github/changeset/types.ts
@@ -8,12 +8,6 @@ export interface RepoCreateItem {
   repo: string
 }
 
-export interface RepoDeleteItem {
-  type: "repo-delete"
-  org: string
-  repo: string
-}
-
 export interface RepoAttribUpdateItem {
   type: "repo-update"
   org: string
@@ -109,7 +103,6 @@ export interface TeamMemberPermissionItem {
  */
 export type ChangeSetItem =
   | RepoCreateItem
-  | RepoDeleteItem
   | RepoAttribUpdateItem
   | RepoTeamPermissionItem
   | RepoTeamAddItem


### PR DESCRIPTION
### Description

We don't have a standardized way of creating repos, and they will often exist independently of resources.yaml. They may be created before, or they may be a short-lived PoC repo. Either way, we don't want to delete them just because they're untracked.

This change removes the repo-delete as a recognized type. Both because we don't want to perform deletion, and because it floods the planned change output with messages like

```
...
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-infra"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-music-monitor-poc"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-performances-web"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-sync"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-tgf"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-tix"}
info   - {"type":"repo-delete","org":"capralifecycle","repo":"tono-typelib"}
info No actions to be performed
```

If we want to do something with unrecognized repos in the future, we can revert this change, but until then, I suggest we clean it up.

### Testing the changes

Build and test the project:

```sh
make
````

Run script using changes:

```sh
node lib/cals-cli.mjs github configure --org capralifecycle --definition-file <path-to-your-resources-definition/resources.yaml> --execute --validate-cache
```